### PR TITLE
Add OpenSearch description

### DIFF
--- a/muchopper/web/__init__.py
+++ b/muchopper/web/__init__.py
@@ -1204,4 +1204,12 @@ def favicon():
     return app.send_static_file('img/favicon.ico')
 
 
+@app.route("/meta/osd.xml")
+def opensearchdescription():
+    return render_static_template(
+        "opensearchdescription.xml",
+        mimetype="application/opensearchdescription+xml"
+    )
+
+
 prometheus_client.core.REGISTRY.register(MetricCollector())

--- a/muchopper/web/__init__.py
+++ b/muchopper/web/__init__.py
@@ -248,10 +248,10 @@ def static_content(generator, path, mimetype):
     return response
 
 
-def render_static_template(path):
+def render_static_template(path, *, mimetype="text/html"):
     return static_content(functools.partial(render_template, path),
                           path,
-                          "text/html")
+                          mimetype)
 
 
 def observe(app):

--- a/muchopper/web/templates/opensearchdescription.xml
+++ b/muchopper/web/templates/opensearchdescription.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Jabber chat room search</ShortName>
+  <Description>Use {{ config["APPNAME"] }} to search for public Jabber chat rooms</Description>
+  <Tags>jabber chat room</Tags>
+  <Url type="text/html"
+       template="{{ url_for('search', _external=True) }}?q={searchTerms}"/>
+  <Query role="example" searchTerms="xmpp" />
+</OpenSearchDescription>

--- a/muchopper/web/templates/skeleton.html
+++ b/muchopper/web/templates/skeleton.html
@@ -10,7 +10,7 @@
 {%- endmacro -%}
 <!DOCTYPE html>
 <html lang="en">
-	<head>
+	<head profile="http://a9.com/-/spec/opensearch/1.1/">
 		<title>{{ title }} - {{ config["APPNAME"] }}</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		{% if config["NOINDEX"] %}
@@ -30,6 +30,7 @@
 		<link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='img/favicon-32x32.png') }}">
 		<link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='img/favicon-16x16.png') }}">
 		<link rel="manifest" href="/site.webmanifest">
+		<link rel="search" type="application/opensearchdescription+xml" href="{{ url_for('opensearchdescription') }}" title="Jabber chat room search">
 		<meta name="msapplication-TileColor" content="#da532c">
 		<meta name="theme-color" content="#ffffff">
 		{% endblock %}


### PR DESCRIPTION
This PR builds the infrastructure necessary to properly emit XML with proper MIME types from the web component. It then adds the OSD XML endpoint as well as the link in the HTML. Works in firefox.

Fixes #43.