### PR TITLE
Hide language if not known by Babel

### DIFF
--- a/muchopper/web/__init__.py
+++ b/muchopper/web/__init__.py
@@ -382,7 +382,7 @@ def prettify_number(n):
 
 
 @app.template_filter('prettify_lang')
-def prettify_lang(s):
+def prettify_lang(s, fallback=True):
     s = str(s)
     try:
         lang_name, region_name = s.split("-", 2)[:2]
@@ -401,7 +401,10 @@ def prettify_lang(s):
         except babel.core.UnknownLocaleError:
             pass
 
-    return s
+    if fallback:
+        return s
+
+    return None
 
 
 @app.template_filter("ccg_rgb_triplet")

--- a/muchopper/web/templates/library.tpl
+++ b/muchopper/web/templates/library.tpl
@@ -58,10 +58,10 @@
 	{% set name = (address.localpart | jid_unescape) or (address | string) %}
 	{% endif %}
 	{% set show_descr = descr and descr != address.localpart %}
-	{% set show_lang = db_language %}
+	{% set show_lang = db_language | prettify_lang(fallback=False) %}
 	{% set is_nonanon = not anonymity_mode or anonymity_mode.value == "none" %}
 	{% set is_closed = not is_open %}
-	{% set set_lang_attr = db_language %}
+	{% set set_lang_attr = show_lang and db_language %}
 	<li class="roomcard">
 		{# this is aria-hidden; we put the number of online users inline with the main content of the room card as a11y text #}
 		<div class="avatar-column" aria-hidden="true">


### PR DESCRIPTION
This is probably a good way to figure out if a language code is
valid or not. This has multiple advantages:

- Incentives for rooms to set the correct language codes
- Do not confuse accessibility tools by emitting non ISO-code
  language tags

Fixes #38.