### PR TITLE
Prometheus endpoints for XMPP components

### DIFF
--- a/muchopper/bot/cli.py
+++ b/muchopper/bot/cli.py
@@ -59,6 +59,7 @@ async def amain(loop, args, cfg):
             map(aioxmpp.JID.fromstr,
                 cfg["muchopping"].get("avatar_whitelist", []))
         ),
+        prometheus_config=cfg.get("prometheus"),
     )
 
     for addr in cfg["muchopping"].get("seed", []):

--- a/muchopper/bot/daemon.py
+++ b/muchopper/bot/daemon.py
@@ -11,6 +11,7 @@ from enum import Enum
 
 import aioxmpp
 
+import muchopper.bot.state
 from . import (
     worker_pool, state, utils, watcher, scanner, insideman, spokesman, mirror
 )
@@ -239,6 +240,11 @@ class MUCHopper:
             bind_host = prometheus_config["bind_address"]
             bind_port = prometheus_config["port"]
             self._prometheus_app = self._setup_prometheus(bind_host, bind_port)
+            if prometheus_config.get("state_metrics", False):
+                import prometheus_client
+                prometheus_client.REGISTRY.register(
+                    muchopper.bot.state.StateMetricsCollector(self._state)
+                )
         else:
             self._prometheus_app = None
 

--- a/muchopper/bot/prometheus.py
+++ b/muchopper/bot/prometheus.py
@@ -1,0 +1,76 @@
+import contextlib
+import functools
+import time
+
+import aiohttp
+from aiohttp import web
+
+import prometheus_client
+import prometheus_client.openmetrics.exposition
+
+
+class PrometheusMetrics:
+    def __init__(self, registry=None):
+        super().__init__()
+        self.registry = registry or prometheus_client.REGISTRY
+        self._response_time_metric = prometheus_client.Summary(
+            "muclumbus_http_response_seconds",
+            "Monotonic time passed for processing a reqeust",
+            ["endpoint", "http_status"]
+        )
+        self._existence_metric = prometheus_client.Gauge(
+            "muclumbus_http_endpoint_flag",
+            "Existence of an endpoint in the code",
+            ["endpoint"],
+        )
+        # self.registry.register(self)
+
+        self.handle_metrics = self.observe("metrics", self.handle_metrics)
+
+    def observe(self, endpoint, f):
+        self._existence_metric.labels("metrics").set(1)
+
+        @functools.wraps(f)
+        async def wrapped(*args, **kwargs):
+            t0 = time.monotonic()
+            status_code = 500
+            try:
+                response = await f(*args, **kwargs)
+                status_code = response.status
+                return response
+            finally:
+                t1 = time.monotonic()
+                self._response_time_metric.labels(
+                    endpoint, str(status_code)
+                ).observe(t1-t0)
+
+        return wrapped
+
+    def collect(self):
+        yield self._existence_metric
+        yield self._response_time_metric
+
+    async def handle_metrics(self, request):
+        content_type = \
+            prometheus_client.openmetrics.exposition.CONTENT_TYPE_LATEST
+        encoder = prometheus_client.openmetrics.exposition.generate_latest
+        return web.Response(
+            body=encoder(self.registry),
+            status=200,
+            content_type=content_type.replace("; charset=utf-8", ""),
+            charset="utf-8",
+        )
+
+
+def make_app(endpoint):
+    app = web.Application()
+    app.add_routes([web.get("/metrics", endpoint.handle_metrics)])
+    return app
+
+
+async def start_app(app, bind_host, bind_port):
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, bind_host, bind_port)
+    await site.start()
+    return runner

--- a/muchopper/bot/promhelpers.py
+++ b/muchopper/bot/promhelpers.py
@@ -21,3 +21,12 @@ def set_optional(metric, value, *, labels=[]):
         metric.labels(*labels).set(value)
     else:
         metric.set(value)
+
+
+def inc_optional(metric, *, labels=[]):
+    if metric is None:
+        return
+    if labels:
+        metric.labels(*labels).inc()
+    else:
+        metric.inc()

--- a/muchopper/bot/promhelpers.py
+++ b/muchopper/bot/promhelpers.py
@@ -1,4 +1,5 @@
 import contextlib
+import time
 
 
 @contextlib.contextmanager
@@ -12,6 +13,24 @@ def time_optional(metric, *labels):
         m = metric
     with m.time():
         yield
+
+
+@contextlib.contextmanager
+def time_optional_late(metric):
+    if metric is None:
+        yield
+        return
+    t0 = time.monotonic()
+    info = {"labels": None}
+    try:
+        yield info
+    finally:
+        t1 = time.monotonic()
+        if info["labels"]:
+            m = metric.labels(*info["labels"])
+        else:
+            m = metric
+        m.observe(t1-t0)
 
 
 def set_optional(metric, value, *, labels=[]):

--- a/muchopper/bot/promhelpers.py
+++ b/muchopper/bot/promhelpers.py
@@ -1,0 +1,23 @@
+import contextlib
+
+
+@contextlib.contextmanager
+def time_optional(metric, *labels):
+    if metric is None:
+        yield
+        return
+    if labels:
+        m = metric.labels(*labels)
+    else:
+        m = metric
+    with m.time():
+        yield
+
+
+def set_optional(metric, value, *, labels=[]):
+    if metric is None:
+        return
+    if labels:
+        metric.labels(*labels).set(value)
+    else:
+        metric.set(value)

--- a/muchopper/bot/watcher.py
+++ b/muchopper/bot/watcher.py
@@ -8,6 +8,7 @@ be configured in a range, and will be scaled according to the number of known
 inactive rooms.
 """
 import asyncio
+import contextlib
 import random
 import sys
 import time
@@ -21,6 +22,7 @@ import aioxmpp.service
 from aioxmpp.utils import namespaces
 
 from . import utils, state, worker_pool
+from .promhelpers import time_optional, set_optional, time_optional_late
 
 
 class Watcher(aioxmpp.service.Service,
@@ -41,6 +43,48 @@ class Watcher(aioxmpp.service.Service,
         self.expire_after = timedelta(days=2)
         self.avatar_whitelist = []
 
+        try:
+            import prometheus_client
+        except ImportError:
+            self._room_scanned_metric = None
+            self._disco_info_duration_metric = None
+            self._avatar_fetch_duration_metric = None
+            self._avatar_proc_duration_metric = None
+            self._pass_duration_metric = None
+            self._last_pass_end_metric = None
+            self._update_duration_metric = None
+        else:
+            self._room_scanned_metric = prometheus_client.Summary(
+                "muclumbus_watcher_room_scan_duration",
+                "Total number of scan operations executed",
+            )
+            self._disco_info_duration_metric = prometheus_client.Summary(
+                "muclumbus_watcher_disco_info_duration_seconds",
+                "Duration of info requests",
+                ["result"]
+            )
+            self._update_duration_metric = prometheus_client.Summary(
+                "muclumbus_watcher_update_duration_seconds",
+                "Duration of database updates",
+            )
+            self._avatar_proc_duration_metric = prometheus_client.Summary(
+                "muclumbus_watcher_avatar_proc_duration_seconds",
+                "Duration of avatar processing",
+            )
+            self._avatar_fetch_duration_metric = prometheus_client.Summary(
+                "muclumbus_watcher_avatar_fetch_duration_seconds",
+                "Duration of avatar requests",
+                ["result"]
+            )
+            self._pass_duration_metric = prometheus_client.Gauge(
+                "muclumbus_watcher_pass_duration_seconds",
+                "Duration of the last pass in seconds"
+            )
+            self._last_pass_end_metric = prometheus_client.Gauge(
+                "muclumbus_watcher_last_pass_end_seconds",
+                "Timestamp of the last pass"
+            )
+
     async def _get_items(self, state):
         items = state.get_all_known_inactive_mucs()
         random.shuffle(items)
@@ -49,48 +93,74 @@ class Watcher(aioxmpp.service.Service,
     async def _process_item(self, state, item, fut):
         self.logger.debug("looking at %s", item)
 
-        try:
-            info = await utils.collect_muc_metadata(self._disco_svc,
-                                                    item,
-                                                    require_fresh=True)
-        except aioxmpp.errors.XMPPCancelError as e:
-            # TODO: follow new address in gone if available
-            if e.condition in ((namespaces.stanzas, "item-not-found"),
-                               (namespaces.stanzas, "gone")):
-                # delete muc
-                self.logger.info(
-                    "MUC %s does not exist anymore, "
-                    "erasing from database",
-                    item,
-                )
-                if fut is not None and not fut.done():
-                    fut.set_exception(e)
-                state.delete_all_muc_data(item)
-                return
-            raise
+        with time_optional(self._room_scanned_metric):
+            with time_optional_late(self._disco_info_duration_metric) as info_m:
+                info_m["labels"] = ["timeout"]
+                try:
+                    info = await utils.collect_muc_metadata(
+                        self._disco_svc,
+                        item,
+                        require_fresh=True)
+                    info_m["labels"] = ["success"]
+                except aioxmpp.errors.XMPPCancelError as e:
+                    info_m["labels"] = [e.condition.value[1]]
+                    # TODO: follow new address in gone if available
+                    if e.condition in (
+                            (namespaces.stanzas, "item-not-found"),
+                            (namespaces.stanzas, "gone")):
+                        # delete muc
+                        self.logger.info(
+                            "MUC %s does not exist anymore, "
+                            "erasing from database",
+                            item,
+                        )
+                        if fut is not None and not fut.done():
+                            fut.set_exception(e)
+                        state.delete_all_muc_data(item)
+                        return
+                    raise
 
-        if info.get("is_public") and (
-                item in self.avatar_whitelist or
-                item.replace(localpart=None) in self.avatar_whitelist):
-            try:
-                avatar = await utils.fetch_avatar(self._vcard_client, item)
-            except aioxmpp.errors.XMPPError as e:
-                self.logger.info("failed to fetch avatar of MUC %s", item)
+            if info.get("is_public") and (
+                    item in self.avatar_whitelist or
+                    item.replace(localpart=None) in self.avatar_whitelist):
+                with time_optional_late(
+                        self._avatar_fetch_duration_metric) as avatar_m:
+                    avatar_m["labels"] = ["success"]
+                    try:
+                        avatar = await utils.fetch_avatar(
+                            self._vcard_client,
+                            item
+                        )
+                    except aioxmpp.errors.XMPPError as e:
+                        avatar_m["labels"] = [e.condition.value[1]]
+                        self.logger.info(
+                            "failed to fetch avatar of MUC %s",
+                            item
+                        )
+                        avatar = None, None
+            else:
                 avatar = None, None
-        else:
-            avatar = None, None
 
-        if fut is not None and not fut.done():
-            fut.set_result(info)
+            if fut is not None and not fut.done():
+                fut.set_result(info)
 
-        self.logger.debug("jid %s: updating metadata: %r",
-                          item, info)
-        state.update_muc_metadata(item, **info)
-        await state.update_muc_avatar(item, *avatar)
+            self.logger.debug("jid %s: updating metadata: %r",
+                              item, info)
+            with time_optional(self._update_duration_metric):
+                state.update_muc_metadata(item, **info)
+
+            with contextlib.ExitStack() as stack:
+                if avatar != (None, None):
+                    stack.enter_context(
+                        time_optional(self._avatar_proc_duration_metric)
+                    )
+                await state.update_muc_avatar(item, *avatar)
         return info
 
     async def _execute(self, state):
-        await super()._execute(state)
+        with time_optional(self._pass_duration_metric):
+            await super()._execute(state)
+        set_optional(self._last_pass_end_metric, time.time())
         # now clean up all stale MUCs
         threshold = datetime.utcnow() - self.expire_after
         self.logger.debug("expiring MUCs which haven’t been seen since %s",


### PR DESCRIPTION
- [x] Optional ``/metrics`` HTTP endpoint
- [ ] XMPP endpoint for metric retrieval with ACL
- [x] Mirror client metrics
- [x] Mirror server metrics
- [x] Search server metrics
- [x] General state metrics (number of MUCs etc.)

   - [x] Stale domain metric

- [x] Scanner metrics
- [x] Watcher metrics