### PR TITLE
Make footer always stick to the bottom of the viewport

### DIFF
--- a/muchopper/web/scss/app.scss
+++ b/muchopper/web/scss/app.scss
@@ -786,3 +786,13 @@ div.search-scope-opt input[type="checkbox"] + label {
 body.no-copy .copy-to-clipboard {
 	display: none !important;
 }
+
+.ym-wbox {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+}
+
+main {
+	flex: 1;
+}


### PR DESCRIPTION
Note that I did test it only in the browser I did not run the entire app :)

Best viewed on sites that have footer in the middle such as https://search.jabber.network/about

Have a nice day! :wave: 