### PR TITLE
Fix typo "bolow" -> "below"

### DIFF
--- a/muchopper/web/templates/tos.html
+++ b/muchopper/web/templates/tos.html
@@ -15,7 +15,7 @@
 <p>We give rooms the benefit of a doubt. Hence, all rooms we can discover are included in the listing automatically. If rooms, however, are found to fall in the <em>out of scope</em> category, they are elegible to be removed from the listing without further notice.</p>
 <p>If we notice that an entire MUC service hosts mostly <em>out of scope</em> rooms, we may block rooms from the entire service from being listed.</p>
 <h4 id="out-of-scope">Out of scope</h4>
-<p>Rooms which willingly (see bolow) allows any of the following in their space are considered out of scope:</p>
+<p>Rooms which willingly (see below) allows any of the following in their space are considered out of scope:</p>
 <ul>
 	<li>Any content where removal of the listing is required per law in Germany</li>
 	<li>Harassment of individuals or groups</li>


### PR DESCRIPTION
May 04

```
sed -i 18s/bolow/below/
```